### PR TITLE
Include Originator in Service Information

### DIFF
--- a/generate-epg
+++ b/generate-epg
@@ -222,7 +222,7 @@ class Generator:
                     bearer = list(filter(lambda x: isinstance(x, DabBearer) and x.ecc == ecc and x.eid == eid, service.bearers))[0]
 
                     # now find PI files
-                    if self.days > 0:
+                    if self.days > 0 and bearer.sid != 0xcdc2 :
                         for i in range(0, self.days):
                            day = now + timedelta(days=i)
                            pi_url = 'http://%s/radiodns/spi/3.1/dab/%03x/%04x/%04x/%01x/%s' % (domain, ((bearer.sid >> 4 & 0xf00) + bearer.ecc), bearer.eid, bearer.sid, bearer.scids, day.strftime("%Y%m%d_PI.xml"))
@@ -291,6 +291,7 @@ class Generator:
         # filename = 'e%02x%04xw%s.EIA' % (ecc, eid, now.strftime("%Y%m%d"))
         if len(all_services) > 0:
             service_info = ServiceInfo()
+            service_info.originator = "OpenDigitalRadio SPI Generator"
             logger.debug('Preparing the Ensemble SI file with %d services to write out as %s', len(all_services), filename)
             for service in all_services:
     


### PR DESCRIPTION
A default originator of "OpenDigitalRadio SPI Generator" is now included in the serviceInformation element.